### PR TITLE
Refactor of the Hazelcast connector constant’s keywords

### DIFF
--- a/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastConnectionConfig.scala
+++ b/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastConnectionConfig.scala
@@ -39,7 +39,7 @@ case class HazelCastSocketConfig(keepAlive: Boolean = true,
 
 object HazelCastConnectionConfig {
   def apply(config: HazelCastSinkConfig): HazelCastConnectionConfig = {
-    val members = config.getList(HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS).toSet
+    val members = config.getList(HazelCastSinkConfigConstants.CLUSTER_MEMBERS).toSet
     val redo = true
     val connectionAttempts = config.getInt(HazelCastSinkConfigConstants.CONNECTION_RETRY_ATTEMPTS)
     val connectionTimeouts = config.getLong(HazelCastSinkConfigConstants.CONNECTION_TIMEOUT)
@@ -49,8 +49,8 @@ object HazelCastConnectionConfig {
     val linger = config.getInt(HazelCastSinkConfigConstants.LINGER_SECONDS)
     val buffer = config.getInt(HazelCastSinkConfigConstants.BUFFER_SIZE)
     val socketConfig = HazelCastSocketConfig(keepAlive, tcpNoDelay, reuse, linger, buffer)
-    val pass = config.getPassword(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD).value()
-    val group = config.getString(HazelCastSinkConfigConstants.SINK_GROUP_NAME)
+    val pass = config.getPassword(HazelCastSinkConfigConstants.GROUP_PASSWORD).value()
+    val group = config.getString(HazelCastSinkConfigConstants.GROUP_NAME)
     new HazelCastConnectionConfig(group, members, redo, connectionAttempts, connectionTimeouts, pass, socketConfig)
   }
 }

--- a/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkConfig.scala
+++ b/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkConfig.scala
@@ -29,8 +29,8 @@ import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
 object HazelCastSinkConfig {
 
   val config: ConfigDef = new ConfigDef()
-    .define(HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS, Type.LIST, Importance.HIGH, HazelCastSinkConfigConstants.CLUSTER_MEMBERS_DOC,
-      "Connection", 1, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS)
+    .define(HazelCastSinkConfigConstants.CLUSTER_MEMBERS, Type.LIST, Importance.HIGH, HazelCastSinkConfigConstants.CLUSTER_MEMBERS_DOC,
+      "Connection", 1, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.CLUSTER_MEMBERS)
     .define(HazelCastSinkConfigConstants.CONNECTION_TIMEOUT, Type.LONG, HazelCastSinkConfigConstants.CONNECTION_TIMEOUT_DEFAULT, Importance.LOW, HazelCastSinkConfigConstants.CONNECTION_TIMEOUT_DOC,
       "Connection", 2, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.CONNECTION_TIMEOUT)
     .define(HazelCastSinkConfigConstants.CONNECTION_RETRY_ATTEMPTS, Type.INT, HazelCastSinkConfigConstants.CONNECTION_RETRY_ATTEMPTS_DEFAULT, Importance.LOW,
@@ -45,10 +45,10 @@ object HazelCastSinkConfig {
       "Connection", 6, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.LINGER_SECONDS)
     .define(HazelCastSinkConfigConstants.BUFFER_SIZE, Type.INT, HazelCastSinkConfigConstants.BUFFER_SIZE_DEFAULT, Importance.LOW, HazelCastSinkConfigConstants.BUFFER_SIZE_DOC,
       "Connection", 7, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.BUFFER_SIZE)
-    .define(HazelCastSinkConfigConstants.SINK_GROUP_NAME, Type.STRING, Importance.HIGH, HazelCastSinkConfigConstants.SINK_GROUP_NAME_DOC,
-      "Connection", 8, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.SINK_GROUP_NAME)
-    .define(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD, Type.PASSWORD, HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DOC,
-      "Connection", 9, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD)
+    .define(HazelCastSinkConfigConstants.GROUP_NAME, Type.STRING, Importance.HIGH, HazelCastSinkConfigConstants.SINK_GROUP_NAME_DOC,
+      "Connection", 8, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.GROUP_NAME)
+    .define(HazelCastSinkConfigConstants.GROUP_PASSWORD, Type.PASSWORD, HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DOC,
+      "Connection", 9, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.GROUP_PASSWORD)
     .define(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY, Type.STRING, Importance.HIGH, HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY,
       "Target", 1, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY)
     .define(HazelCastSinkConfigConstants.ERROR_POLICY, Type.STRING, HazelCastSinkConfigConstants.ERROR_POLICY_DEFAULT, Importance.HIGH, HazelCastSinkConfigConstants.ERROR_POLICY_DOC,
@@ -57,7 +57,7 @@ object HazelCastSinkConfig {
       "Target", 3, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.ERROR_RETRY_INTERVAL)
     .define(HazelCastSinkConfigConstants.NBR_OF_RETRIES, Type.INT, HazelCastSinkConfigConstants.NBR_OF_RETIRES_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.NBR_OF_RETRIES_DOC,
       "Target", 4, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.NBR_OF_RETRIES)
-    .define(HazelCastSinkConfigConstants.SINK_THREAD_POOL_CONFIG, Type.INT, HazelCastSinkConfigConstants.SINK_THREAD_POOL_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.SINK_THREAD_POOL_DOC,
+    .define(HazelCastSinkConfigConstants.THREAD_POOL_CONFIG, Type.INT, HazelCastSinkConfigConstants.SINK_THREAD_POOL_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.SINK_THREAD_POOL_DOC,
       "Target", 5, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.SINK_THREAD_POOL_DISPLAY)
     .define(HazelCastSinkConfigConstants.PARALLEL_WRITE, Type.BOOLEAN, HazelCastSinkConfigConstants.PARALLEL_WRITE_DEFAULT, Importance.MEDIUM, HazelCastSinkConfigConstants.PARALLEL_WRITE_DOC,
       "Target", 5, ConfigDef.Width.MEDIUM, HazelCastSinkConfigConstants.PARALLEL_WRITE)

--- a/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkConfigConstants.scala
+++ b/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkConfigConstants.scala
@@ -25,8 +25,7 @@ import com.datamountaineer.streamreactor.temp.const.TraitConfigConst._
 object HazelCastSinkConfigConstants {
   val HAZELCAST_CONNECTOR_PREFIX = "connect.hazelcast"
 
-  val CLUSTER_SOURCE_MEMBERS = s"$HAZELCAST_CONNECTOR_PREFIX.source.cluster.members"
-  val CLUSTER_SINK_MEMBERS = s"$HAZELCAST_CONNECTOR_PREFIX.sink.cluster.members"
+  val CLUSTER_MEMBERS = s"$HAZELCAST_CONNECTOR_PREFIX.cluster.members"
   val CLUSTER_MEMBERS_DOC: String =
     """
       |Address List is the initial list of cluster addresses to which the client will connect.
@@ -35,10 +34,10 @@ object HazelCastSinkConfigConstants {
       |it is recommended that you give the addresses for all the nodes.""".stripMargin
   val CLUSTER_MEMBERS_DEFAULT = "localhost"
 
-  val SINK_GROUP_NAME = s"$HAZELCAST_CONNECTOR_PREFIX.sink.group.name"
+  val GROUP_NAME = s"$HAZELCAST_CONNECTOR_PREFIX.group.name"
   val SINK_GROUP_NAME_DOC = "The group name of the connector in the target Hazelcast cluster."
 
-  val SINK_GROUP_PASSWORD = s"$HAZELCAST_CONNECTOR_PREFIX.sink.group.password"
+  val GROUP_PASSWORD = s"$HAZELCAST_CONNECTOR_PREFIX.group.password"
   val SINK_GROUP_PASSWORD_DOC: String = """The password for the group name.""".stripMargin
   val SINK_GROUP_PASSWORD_DEFAULT = "dev-pass"
 
@@ -94,7 +93,7 @@ object HazelCastSinkConfigConstants {
       |The error will be logged automatically""".stripMargin
   val ERROR_POLICY_DEFAULT = "THROW"
 
-  val ERROR_RETRY_INTERVAL = s"$HAZELCAST_CONNECTOR_PREFIX.sink.retry.interval"
+  val ERROR_RETRY_INTERVAL = s"$HAZELCAST_CONNECTOR_PREFIX.retry.interval"
   val ERROR_RETRY_INTERVAL_DOC = "The time in milliseconds between retries."
   val ERROR_RETRY_INTERVAL_DEFAULT = "60000"
 
@@ -102,7 +101,7 @@ object HazelCastSinkConfigConstants {
   val NBR_OF_RETRIES_DOC = "The maximum number of times to try the write again."
   val NBR_OF_RETIRES_DEFAULT = 20
 
-  val SINK_THREAD_POOL_CONFIG = s"$HAZELCAST_CONNECTOR_PREFIX.$THREAD_POLL_PROP_SUFFIX"
+  val THREAD_POOL_CONFIG = s"$HAZELCAST_CONNECTOR_PREFIX.$THREAD_POLL_PROP_SUFFIX"
   val SINK_THREAD_POOL_DOC =
     """
       |The sink inserts all the data concurrently. To fail fast in case of an error, the sink has its own thread pool.

--- a/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkSettings.scala
+++ b/kafka-connect-hazelcast/src/main/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/HazelCastSinkSettings.scala
@@ -96,8 +96,8 @@ object HazelCastSinkSettings {
   }
 
   private def ensureGroupNameExists(config: HazelCastSinkConfig): Unit = {
-    val groupName = config.getString(HazelCastSinkConfigConstants.SINK_GROUP_NAME)
-    require(groupName.nonEmpty, s"No ${HazelCastSinkConfigConstants.SINK_GROUP_NAME} provided!")
+    val groupName = config.getString(HazelCastSinkConfigConstants.GROUP_NAME)
+    require(groupName.nonEmpty, s"No ${HazelCastSinkConfigConstants.GROUP_NAME} provided!")
   }
 
   private def getFormatType(format: FormatType): FormatType = {

--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/TestBase.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/TestBase.scala
@@ -52,7 +52,7 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
   val EXPORT_MAP_JSON=s"INSERT INTO $TABLE SELECT * FROM $TOPIC WITHFORMAT json"
   val EXPORT_MAP_SELECTION = s"INSERT INTO $TABLE SELECT a, b, c FROM $TOPIC"
   val EXPORT_MAP_IGNORED = s"INSERT INTO $TABLE SELECT * FROM $TOPIC IGNORE a"
-  val GROUP_NAME = "dev"
+  val TESTS_GROUP_NAME = "dev"
   val json = "{\"id\":\"sink_test-12-1\",\"int_field\":12,\"long_field\":12,\"string_field\":\"foo\",\"float_field\":0.1,\"float64_field\":0.199999,\"boolean_field\":true,\"byte_field\":\"Ynl0ZXM=\"}"
 
   protected val PARTITION: Int = 12
@@ -63,80 +63,80 @@ trait TestBase extends WordSpec with BeforeAndAfter with Matchers {
 
   def getProps = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsRB = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_RB,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonQueue = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_JSON_QUEUE,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonSet = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_JSON_SET,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonList = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_JSON_LIST,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonMultiMapDefaultPKS = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_MULTIMAP_DEFAULT_PK,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonICache = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_JSON_ICACHE,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJsonMapDefaultPKS = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_IMAP_DEFAULT_PK,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 
   def getPropsJson = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_JSON,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
 
     ).asJava
   }
 
   def getPropsSelection = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_SELECTION,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-        HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+        HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
 
     ).asJava
   }
 
   def getPropsIgnored = {
     Map(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY->EXPORT_MAP_IGNORED,
-      HazelCastSinkConfigConstants.SINK_GROUP_NAME->GROUP_NAME,
-      HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS->"localhost"
+      HazelCastSinkConfigConstants.GROUP_NAME->TESTS_GROUP_NAME,
+      HazelCastSinkConfigConstants.CLUSTER_MEMBERS->"localhost"
     ).asJava
   }
 

--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkConstants.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkConstants.scala
@@ -16,18 +16,17 @@
 
 package com.datamountaineer.streamreactor.connect.hazelcast.config
 
-import com.datamountaineer.streamreactor.connect.hazelcast.TestBase
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 /**
   * The point of this test is to check that constants keys are not changed after the refactor of the code.
   */
-class TestHazelCastSinkConstants extends TestBase {
+class TestHazelCastSinkConstants extends WordSpec with BeforeAndAfter with Matchers {
 
   // Constants
-  val CLUSTER_SOURCE_MEMBERS = "connect.hazelcast.source.cluster.members"
-  val CLUSTER_SINK_MEMBERS = "connect.hazelcast.sink.cluster.members"
-  val SINK_GROUP_NAME = "connect.hazelcast.sink.group.name"
-  val SINK_GROUP_PASSWORD = "connect.hazelcast.sink.group.password"
+  val CLUSTER_MEMBERS = "connect.hazelcast.cluster.members"
+  val GROUP_NAME = "connect.hazelcast.group.name"
+  val GROUP_PASSWORD = "connect.hazelcast.group.password"
   val PARALLEL_WRITE = "connect.hazelcast.parallel.write"
   val CONNECTION_TIMEOUT = "connect.hazelcast.connection.timeout"
   val CONNECTION_RETRY_ATTEMPTS = "connect.hazelcast.connection.retries"
@@ -38,21 +37,18 @@ class TestHazelCastSinkConstants extends TestBase {
   val BUFFER_SIZE = "connect.hazelcast.connection.buffer.size"
   val EXPORT_ROUTE_QUERY = "connect.hazelcast.kcql"
   val ERROR_POLICY = "connect.hazelcast.error.policy"
-  val ERROR_RETRY_INTERVAL = "connect.hazelcast.sink.retry.interval"
+  val ERROR_RETRY_INTERVAL = "connect.hazelcast.retry.interval"
   val NBR_OF_RETRIES = "connect.hazelcast.max.retries"
-  val SINK_THREAD_POOL_CONFIG = "connect.hazelcast.threadpool.size"
+  val THREAD_POOL_CONFIG = "connect.hazelcast.threadpool.size"
 
   "CLUSTER_SOURCE_MEMBERS should have the same key in HazelCastSinkConfigConstants" in {
-    assert(CLUSTER_SOURCE_MEMBERS.equals(HazelCastSinkConfigConstants.CLUSTER_SOURCE_MEMBERS))
-  }
-  "CLUSTER_SINK_MEMBERS should have the same key in HazelCastSinkConfigConstants" in {
-    assert(CLUSTER_SINK_MEMBERS.equals(HazelCastSinkConfigConstants.CLUSTER_SINK_MEMBERS))
+    assert(CLUSTER_MEMBERS.equals(HazelCastSinkConfigConstants.CLUSTER_MEMBERS))
   }
   "SINK_GROUP_NAME should have the same key in HazelCastSinkConfigConstants" in {
-    assert(SINK_GROUP_NAME.equals(HazelCastSinkConfigConstants.SINK_GROUP_NAME))
+    assert(GROUP_NAME.equals(HazelCastSinkConfigConstants.GROUP_NAME))
   }
   "SINK_GROUP_PASSWORD should have the same key in HazelCastSinkConfigConstants" in {
-    assert(SINK_GROUP_PASSWORD.equals(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD))
+    assert(GROUP_PASSWORD.equals(HazelCastSinkConfigConstants.GROUP_PASSWORD))
   }
   "PARALLEL_WRITE should have the same key in HazelCastSinkConfigConstants" in {
     assert(PARALLEL_WRITE.equals(HazelCastSinkConfigConstants.PARALLEL_WRITE))
@@ -91,6 +87,6 @@ class TestHazelCastSinkConstants extends TestBase {
     assert(NBR_OF_RETRIES.equals(HazelCastSinkConfigConstants.NBR_OF_RETRIES))
   }
   "SINK_THREAD_POOL_CONFIG should have the same key in HazelCastSinkConfigConstants" in {
-    assert(SINK_THREAD_POOL_CONFIG.equals(HazelCastSinkConfigConstants.SINK_THREAD_POOL_CONFIG))
+    assert(THREAD_POOL_CONFIG.equals(HazelCastSinkConfigConstants.THREAD_POOL_CONFIG))
   }
 }

--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkSettings.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkSettings.scala
@@ -33,7 +33,7 @@ class TestHazelCastSinkSettings extends TestBase {
 
   before {
     val configApp1 = new Config()
-    configApp1.getGroupConfig.setName(GROUP_NAME).setPassword(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT)
+    configApp1.getGroupConfig.setName(TESTS_GROUP_NAME).setPassword(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT)
     instance = Hazelcast.newHazelcastInstance(configApp1)
   }
 

--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/sink/TestHazelCastSinkConnector.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/sink/TestHazelCastSinkConnector.scala
@@ -32,7 +32,7 @@ class TestHazelCastSinkConnector extends TestBase {
     connector.start(props)
     val taskConfigs = connector.taskConfigs(1)
     taskConfigs.asScala.head.get(HazelCastSinkConfigConstants.EXPORT_ROUTE_QUERY) shouldBe EXPORT_MAP
-    taskConfigs.asScala.head.get(HazelCastSinkConfigConstants.SINK_GROUP_NAME) shouldBe GROUP_NAME
+    taskConfigs.asScala.head.get(HazelCastSinkConfigConstants.GROUP_NAME) shouldBe TESTS_GROUP_NAME
     connector.stop()
   }
 }

--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/sink/TestHazelCastSinkTask.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/sink/TestHazelCastSinkTask.scala
@@ -35,7 +35,7 @@ class TestHazelCastSinkTask extends TestBase with MockitoSugar {
   "should start SinkTask and write json" in {
     val configApp1 = new Config()
     configApp1.setProperty( "hazelcast.logging.type", "log4j" )
-    configApp1.getGroupConfig.setName(GROUP_NAME).setPassword(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT)
+    configApp1.getGroupConfig.setName(TESTS_GROUP_NAME).setPassword(HazelCastSinkConfigConstants.SINK_GROUP_PASSWORD_DEFAULT)
     val instance = Hazelcast.newHazelcastInstance(configApp1)
 
 


### PR DESCRIPTION
Refactor of the Hazelcast connector constant’s keywords, so that they do not mention sink/source