### PR TITLE
Refactor of the Cassandra connector constant’s keywords

### DIFF
--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfig.scala
@@ -227,14 +227,14 @@ object CassandraConfigSource {
       ConfigDef.Width.LONG,
       CassandraConfigConstants.ASSIGNED_TABLES)
 
-    .define(CassandraConfigConstants.SOURCE_KCQL_QUERY,
+    .define(CassandraConfigConstants.ROUTE_QUERY,
       Type.STRING,
       Importance.HIGH,
-      CassandraConfigConstants.SOURCE_KCQL_DOC,
+      CassandraConfigConstants.ROUTE_QUERY_DOC,
       "Mappings",
       2,
       ConfigDef.Width.LONG,
-      CassandraConfigConstants.SOURCE_KCQL_QUERY)
+      CassandraConfigConstants.ROUTE_QUERY)
 
 
     .define(CassandraConfigConstants.READER_BUFFER_SIZE,
@@ -304,23 +304,23 @@ case class CassandraConfigSource(props: util.Map[String, String])
 object CassandraConfigSink {
   val base = CassandraConfig().configDef
   val sinkConfig = base
-    .define(CassandraConfigConstants.SINK_KCQL,
+    .define(CassandraConfigConstants.ROUTE_QUERY,
       Type.STRING,
       Importance.HIGH,
-      CassandraConfigConstants.SINK_KCQL_DOC,
+      CassandraConfigConstants.ROUTE_QUERY_DOC,
       "Mappings",
       1,
       ConfigDef.Width.LONG,
-      CassandraConfigConstants.SINK_KCQL)
-    .define(CassandraConfigConstants.SINK_THREAD_POOL_CONFIG,
+      CassandraConfigConstants.ROUTE_QUERY)
+    .define(CassandraConfigConstants.THREAD_POOL_CONFIG,
       Type.INT,
-      CassandraConfigConstants.SINK_THREAD_POOL_DEFAULT,
+      CassandraConfigConstants.THREAD_POOL_DEFAULT,
       Importance.MEDIUM,
-      CassandraConfigConstants.SINK_THREAD_POOL_DOC,
+      CassandraConfigConstants.THREAD_POOL_DOC,
       "Import",
       8,
       ConfigDef.Width.MEDIUM,
-      CassandraConfigConstants.SINK_THREAD_POOL_DISPLAY
+      CassandraConfigConstants.THREAD_POOL_DISPLAY
     )
 }
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/config/CassandraConfigConstants.scala
@@ -94,11 +94,11 @@ object CassandraConfigConstants {
   val BATCH_SIZE_DOC = "The number of records the source task should drain from the reader queue."
   val BATCH_SIZE_DEFAULT = 100
 
-  val READER_BUFFER_SIZE = s"$CASSANDRA_CONNECTOR_PREFIX.source.task.buffer.size"
+  val READER_BUFFER_SIZE = s"$CASSANDRA_CONNECTOR_PREFIX.task.buffer.size"
   val READER_BUFFER_SIZE_DOC = "The size of the queue as read writes to."
   val READER_BUFFER_SIZE_DEFAULT = 10000
 
-  val ALLOW_FILTERING = s"$CASSANDRA_CONNECTOR_PREFIX.import.source.allow.filtering"
+  val ALLOW_FILTERING = s"$CASSANDRA_CONNECTOR_PREFIX.import.allow.filtering"
   val ALLOW_FILTERING_DOC = "Enable ALLOW FILTERING in incremental selects."
   val ALLOW_FILTERING_DEFAULT = true
 
@@ -130,20 +130,17 @@ object CassandraConfigConstants {
   val NBR_OF_RETIRES_DEFAULT = 20
 
 
-  val SINK_KCQL = s"$CASSANDRA_CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
-  val SINK_KCQL_DOC = "KCQL expression describing field selection and routes."
+  val ROUTE_QUERY = s"$CASSANDRA_CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
+  val ROUTE_QUERY_DOC = "KCQL expression describing field selection and routes."
 
-  val SOURCE_KCQL_QUERY = s"$CASSANDRA_CONNECTOR_PREFIX.$KCQL_PROP_SUFFIX"
-  val SOURCE_KCQL_DOC = "KCQL expression describing field selection and routes."
-
-  val SINK_THREAD_POOL_CONFIG = s"$CASSANDRA_CONNECTOR_PREFIX.$THREAD_POLL_PROP_SUFFIX"
-  val SINK_THREAD_POOL_DOC =
+  val THREAD_POOL_CONFIG = s"$CASSANDRA_CONNECTOR_PREFIX.$THREAD_POLL_PROP_SUFFIX"
+  val THREAD_POOL_DOC =
     """
       |The sink inserts all the data concurrently. To fail fast in case of an error, the sink has its own thread pool.
       |Set the value to zero and the threadpool will default to 4* NO_OF_CPUs. Set a value greater than 0
       |and that would be the size of this threadpool.""".stripMargin
-  val SINK_THREAD_POOL_DISPLAY = "Thread pool size"
-  val SINK_THREAD_POOL_DEFAULT = 0
+  val THREAD_POOL_DISPLAY = "Thread pool size"
+  val THREAD_POOL_DEFAULT = 0
 
   val CONSISTENCY_LEVEL_CONFIG = s"$CASSANDRA_CONNECTOR_PREFIX.$CONSISTENCY_LEVEL_PROP_SUFFIX"
   val CONSISTENCY_LEVEL_DOC =
@@ -155,7 +152,7 @@ object CassandraConfigConstants {
   val CONSISTENCY_LEVEL_DEFAULT = ""
 
 
-  val TIMESTAMP_TYPE = s"$CASSANDRA_CONNECTOR_PREFIX.source.timestamp.type"
+  val TIMESTAMP_TYPE = s"$CASSANDRA_CONNECTOR_PREFIX.timestamp.type"
   val TIMESTAMP_TYPE_DOC = "The Cassandra data type of the timestamp column, either timeuuid (default) or timestamp."
   val TIMESTAMP_TYPE_DEFAULT = "timeUUID"
 

--- a/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
+++ b/kafka-connect-cassandra/src/main/scala/com/datamountaineer/streamreactor/connect/cassandra/source/CassandraSourceConnector.scala
@@ -53,7 +53,7 @@ class CassandraSourceConnector extends SourceConnector with StrictLogging {
     * @return a List of configuration properties per worker.
     **/
   override def taskConfigs(maxTasks: Int): util.List[util.Map[String, String]] = {
-    val raw = configProps.get.get(CassandraConfigConstants.SOURCE_KCQL_QUERY).split(";")
+    val raw = configProps.get.get(CassandraConfigConstants.ROUTE_QUERY).split(";")
 
     val tables = raw.map { r => Config.parse(r).getSource }.toList
 

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/TestConfig.scala
@@ -96,7 +96,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL
     ).asJava
   }
 
@@ -106,7 +106,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL
     ).asJava
   }
 
@@ -116,7 +116,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_SELECTION
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_SELECTION
     ).asJava
   }
 
@@ -127,7 +127,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL,
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL,
       CassandraConfigConstants.ERROR_POLICY -> ErrorPolicyEnum.RETRY.toString
     ).asJava
   }
@@ -138,7 +138,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL,
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL,
       CassandraConfigConstants.ERROR_POLICY -> ErrorPolicyEnum.NOOP.toString
     ).asJava
   }
@@ -152,7 +152,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.SSL_ENABLED -> "true",
       CassandraConfigConstants.TRUST_STORE_PATH -> TRUST_STORE_PATH,
       CassandraConfigConstants.TRUST_STORE_PASSWD -> TRUST_STORE_PASSWORD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL
     ).asJava
   }
 
@@ -168,7 +168,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.USE_CLIENT_AUTH -> "false",
       CassandraConfigConstants.KEY_STORE_PATH -> KEYSTORE_PATH,
       CassandraConfigConstants.KEY_STORE_PASSWD -> KEYSTORE_PASSWORD,
-      CassandraConfigConstants.SINK_KCQL -> QUERY_ALL
+      CassandraConfigConstants.ROUTE_QUERY -> QUERY_ALL
     ).asJava
   }
 
@@ -189,7 +189,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SOURCE_KCQL_QUERY -> IMPORT_QUERY_ALL,
+      CassandraConfigConstants.ROUTE_QUERY -> IMPORT_QUERY_ALL,
       CassandraConfigConstants.ASSIGNED_TABLES -> ASSIGNED_TABLES,
       CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.BULK,
       CassandraConfigConstants.POLL_INTERVAL -> "1000"
@@ -202,7 +202,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SOURCE_KCQL_QUERY -> IMPORT_QUERY_INCR,
+      CassandraConfigConstants.ROUTE_QUERY -> IMPORT_QUERY_INCR,
       CassandraConfigConstants.ASSIGNED_TABLES -> ASSIGNED_TABLES,
       CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
       //CassandraConfigConstants.TABLE_TIMESTAMP_COL_MAP->TIMESTAMP_COL_MAP,
@@ -216,7 +216,7 @@ trait TestConfig extends StrictLogging with MockitoSugar {
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO $TOPIC4 SELECT * FROM $TABLE4 PK timestamp_field",
+      CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO $TOPIC4 SELECT * FROM $TABLE4 PK timestamp_field",
       //CassandraConfigConstants.ASSIGNED_TABLES -> TABLE4,
       CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
       //CassandraConfigConstants.TABLE_TIMESTAMP_COL_MAP->TIMESTAMP_COL_MAP,

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraConstants.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraConstants.scala
@@ -40,97 +40,93 @@ class TestCassandraConstants extends WordSpec with Matchers {
   val KEY_STORE_TYPE = "connect.cassandra.key.store.type"
   val IMPORT_MODE = "connect.cassandra.import.mode"
   val BATCH_SIZE = "connect.cassandra.batch.size"
-  val READER_BUFFER_SIZE = "connect.cassandra.source.task.buffer.size"
-  val ALLOW_FILTERING = "connect.cassandra.import.source.allow.filtering"
+  val READER_BUFFER_SIZE = "connect.cassandra.task.buffer.size"
+  val ALLOW_FILTERING = "connect.cassandra.import.allow.filtering"
   val ASSIGNED_TABLES = "connect.cassandra.assigned.tables"
   val ERROR_POLICY = "connect.cassandra.error.policy"
   val ERROR_RETRY_INTERVAL = "connect.cassandra.retry.interval"
   val NBR_OF_RETRIES = "connect.cassandra.max.retries"
-  val SINK_KCQL = "connect.cassandra.kcql"
-  val SOURCE_KCQL_QUERY = "connect.cassandra.kcql"
-  val SINK_THREAD_POOL_CONFIG = "connect.cassandra.threadpool.size"
+  val ROUTE_QUERY = "connect.cassandra.kcql"
+  val THREAD_POOL_CONFIG = "connect.cassandra.threadpool.size"
   val CONSISTENCY_LEVEL_CONFIG = "connect.cassandra.consistency.level"
-  val TIMESTAMP_TYPE = "connect.cassandra.source.timestamp.type"
+  val TIMESTAMP_TYPE = "connect.cassandra.timestamp.type"
 
-  "POLL_INTERVAL should be equals to the same key in CassandraConfigConstants" in {
+  "POLL_INTERVAL should have the same key in CassandraConfigConstants" in {
     assert(POLL_INTERVAL.equals(CassandraConfigConstants.POLL_INTERVAL))
   }
-  "KEY_SPACE should be equals to the same key in CassandraConfigConstants" in {
+  "KEY_SPACE should have the same key in CassandraConfigConstants" in {
     assert(KEY_SPACE.equals(CassandraConfigConstants.KEY_SPACE))
   }
-  "CONTACT_POINTS should be equals to the same key in CassandraConfigConstants" in {
+  "CONTACT_POINTS should have the same key in CassandraConfigConstants" in {
     assert(CONTACT_POINTS.equals(CassandraConfigConstants.CONTACT_POINTS))
   }
-  "PORT should be equals to the same key in CassandraConfigConstants" in {
+  "PORT should have the same key in CassandraConfigConstants" in {
     assert(PORT.equals(CassandraConfigConstants.PORT))
   }
-  "USERNAME should be equals to the same key in CassandraConfigConstants" in {
+  "USERNAME should have the same key in CassandraConfigConstants" in {
     assert(USERNAME.equals(CassandraConfigConstants.USERNAME))
   }
-  "PASSWD should be equals to the same key in CassandraConfigConstants" in {
+  "PASSWD should have the same key in CassandraConfigConstants" in {
     assert(PASSWD.equals(CassandraConfigConstants.PASSWD))
   }
-  "SSL_ENABLED should be equals to the same key in CassandraConfigConstants" in {
+  "SSL_ENABLED should have the same key in CassandraConfigConstants" in {
     assert(SSL_ENABLED.equals(CassandraConfigConstants.SSL_ENABLED))
   }
-  "TRUST_STORE_PATH should be equals to the same key in CassandraConfigConstants" in {
+  "TRUST_STORE_PATH should have the same key in CassandraConfigConstants" in {
     assert(TRUST_STORE_PATH.equals(CassandraConfigConstants.TRUST_STORE_PATH))
   }
-  "TRUST_STORE_PASSWD should be equals to the same key in CassandraConfigConstants" in {
+  "TRUST_STORE_PASSWD should have the same key in CassandraConfigConstants" in {
     assert(TRUST_STORE_PASSWD.equals(CassandraConfigConstants.TRUST_STORE_PASSWD))
   }
-  "TRUST_STORE_TYPE should be equals to the same key in CassandraConfigConstants" in {
+  "TRUST_STORE_TYPE should have the same key in CassandraConfigConstants" in {
     assert(TRUST_STORE_TYPE.equals(CassandraConfigConstants.TRUST_STORE_TYPE))
   }
-  "USE_CLIENT_AUTH should be equals to the same key in CassandraConfigConstants" in {
+  "USE_CLIENT_AUTH should have the same key in CassandraConfigConstants" in {
     assert(USE_CLIENT_AUTH.equals(CassandraConfigConstants.USE_CLIENT_AUTH))
   }
-  "KEY_STORE_PATH should be equals to the same key in CassandraConfigConstants" in {
+  "KEY_STORE_PATH should have the same key in CassandraConfigConstants" in {
     assert(KEY_STORE_PATH.equals(CassandraConfigConstants.KEY_STORE_PATH))
   }
-  "KEY_STORE_PASSWD should be equals to the same key in CassandraConfigConstants" in {
+  "KEY_STORE_PASSWD should have the same key in CassandraConfigConstants" in {
     assert(KEY_STORE_PASSWD.equals(CassandraConfigConstants.KEY_STORE_PASSWD))
   }
-  "KEY_STORE_TYPE should be equals to the same key in CassandraConfigConstants" in {
+  "KEY_STORE_TYPE should have the same key in CassandraConfigConstants" in {
     assert(KEY_STORE_TYPE.equals(CassandraConfigConstants.KEY_STORE_TYPE))
   }
-  "IMPORT_MODE should be equals to the same key in CassandraConfigConstants" in {
+  "IMPORT_MODE should have the same key in CassandraConfigConstants" in {
     assert(IMPORT_MODE.equals(CassandraConfigConstants.IMPORT_MODE))
   }
-  "BATCH_SIZE should be equals to the same key in CassandraConfigConstants" in {
+  "BATCH_SIZE should have the same key in CassandraConfigConstants" in {
     assert(BATCH_SIZE.equals(CassandraConfigConstants.BATCH_SIZE))
   }
-  "READER_BUFFER_SIZE should be equals to the same key in CassandraConfigConstants" in {
+  "READER_BUFFER_SIZE should have the same key in CassandraConfigConstants" in {
     assert(READER_BUFFER_SIZE.equals(CassandraConfigConstants.READER_BUFFER_SIZE))
   }
-  "ALLOW_FILTERING should be equals to the same key in CassandraConfigConstants" in {
+  "ALLOW_FILTERING should have the same key in CassandraConfigConstants" in {
     assert(ALLOW_FILTERING.equals(CassandraConfigConstants.ALLOW_FILTERING))
   }
-  "ASSIGNED_TABLES should be equals to the same key in CassandraConfigConstants" in {
+  "ASSIGNED_TABLES should have the same key in CassandraConfigConstants" in {
     assert(ASSIGNED_TABLES.equals(CassandraConfigConstants.ASSIGNED_TABLES))
   }
-  "ERROR_POLICY should be equals to the same key in CassandraConfigConstants" in {
+  "ERROR_POLICY should have the same key in CassandraConfigConstants" in {
     assert(ERROR_POLICY.equals(CassandraConfigConstants.ERROR_POLICY))
   }
-  "ERROR_RETRY_INTERVAL should be equals to the same key in CassandraConfigConstants" in {
+  "ERROR_RETRY_INTERVAL should have the same key in CassandraConfigConstants" in {
     assert(ERROR_RETRY_INTERVAL.equals(CassandraConfigConstants.ERROR_RETRY_INTERVAL))
   }
-  "NBR_OF_RETRIES should be equals to the same key in CassandraConfigConstants" in {
+  "NBR_OF_RETRIES should have the same key in CassandraConfigConstants" in {
     assert(NBR_OF_RETRIES.equals(CassandraConfigConstants.NBR_OF_RETRIES))
   }
-  "SINK_KCQL should be equals to the same key in CassandraConfigConstants" in {
-    assert(SINK_KCQL.equals(CassandraConfigConstants.SINK_KCQL))
+  "ROUTE_QUERY should have the same key in CassandraConfigConstants" in {
+    assert(ROUTE_QUERY.equals(CassandraConfigConstants.ROUTE_QUERY))
   }
-  "SOURCE_KCQL_QUERY should be equals to the same key in CassandraConfigConstants" in {
-    assert(SOURCE_KCQL_QUERY.equals(CassandraConfigConstants.SOURCE_KCQL_QUERY))
+  "THREAD_POOL_CONFIG should have the same key in CassandraConfigConstants" in {
+    assert(THREAD_POOL_CONFIG.equals(CassandraConfigConstants.THREAD_POOL_CONFIG))
   }
-  "SINK_THREAD_POOL_CONFIG should be equals to the same key in CassandraConfigConstants" in {
-    assert(SINK_THREAD_POOL_CONFIG.equals(CassandraConfigConstants.SINK_THREAD_POOL_CONFIG))
-  }
-  "CONSISTENCY_LEVEL_CONFIG should be equals to the same key in CassandraConfigConstants" in {
+  "CONSISTENCY_LEVEL_CONFIG should have the same key in CassandraConfigConstants" in {
     assert(CONSISTENCY_LEVEL_CONFIG.equals(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG))
   }
-  "TIMESTAMP_TYPE should be equals to the same key in CassandraConfigConstants" in {
+  "TIMESTAMP_TYPE should have the same key in CassandraConfigConstants" in {
     assert(TIMESTAMP_TYPE.equals(CassandraConfigConstants.TIMESTAMP_TYPE))
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkConfig.scala
@@ -27,7 +27,7 @@ class TestCassandraSinkConfig extends WordSpec with BeforeAndAfter with Matchers
     taskConfig.getString(CassandraConfigConstants.KEY_SPACE) shouldBe CASSANDRA_KEYSPACE
     taskConfig.getString(CassandraConfigConstants.USERNAME) shouldBe USERNAME
     taskConfig.getPassword(CassandraConfigConstants.PASSWD).value shouldBe PASSWD
-    taskConfig.getString(CassandraConfigConstants.SINK_KCQL) shouldBe QUERY_ALL
+    taskConfig.getString(CassandraConfigConstants.ROUTE_QUERY) shouldBe QUERY_ALL
     taskConfig.getString(CassandraConfigConstants.CONSISTENCY_LEVEL_CONFIG) shouldBe CassandraConfigConstants.CONSISTENCY_LEVEL_DEFAULT
   }
 
@@ -41,7 +41,7 @@ class TestCassandraSinkConfig extends WordSpec with BeforeAndAfter with Matchers
     taskConfig.getString(CassandraConfigConstants.TRUST_STORE_PATH) shouldBe TRUST_STORE_PATH
     taskConfig.getPassword(CassandraConfigConstants.TRUST_STORE_PASSWD).value shouldBe TRUST_STORE_PASSWORD
     //taskConfig.getString(CassandraConfigConstants.EXPORT_MAPPINGS) shouldBe EXPORT_TOPIC_TABLE_MAP
-    taskConfig.getString(CassandraConfigConstants.SINK_KCQL) shouldBe QUERY_ALL
+    taskConfig.getString(CassandraConfigConstants.ROUTE_QUERY) shouldBe QUERY_ALL
   }
 
   "A CassandraConfig should return configured for SSL without client certficate authentication" in {
@@ -56,6 +56,6 @@ class TestCassandraSinkConfig extends WordSpec with BeforeAndAfter with Matchers
     taskConfig.getBoolean(CassandraConfigConstants.USE_CLIENT_AUTH) shouldBe false
     taskConfig.getString(CassandraConfigConstants.KEY_STORE_PATH) shouldBe KEYSTORE_PATH
     taskConfig.getPassword(CassandraConfigConstants.KEY_STORE_PASSWD).value shouldBe KEYSTORE_PASSWORD
-    taskConfig.getString(CassandraConfigConstants.SINK_KCQL) shouldBe QUERY_ALL
+    taskConfig.getString(CassandraConfigConstants.ROUTE_QUERY) shouldBe QUERY_ALL
   }
 }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSinkSettings.scala
@@ -70,14 +70,14 @@ class TestCassandraSinkSettings extends WordSpec with Matchers with MockitoSugar
 
   "CassandraSettings should allow setting the sink thread pool to 64" in {
     val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.SINK_THREAD_POOL_CONFIG, "64")
+    map.put(CassandraConfigConstants.THREAD_POOL_CONFIG, "64")
     val settings = CassandraSettings.configureSink(CassandraConfigSink(map))
     settings.threadPoolSize shouldBe 64
   }
 
   "CassandraSettings should handle setting the sink thread pool to 0 and return a non zero value" in {
     val map = new util.HashMap[String, String](getCassandraConfigSinkPropsRetry)
-    map.put(CassandraConfigConstants.SINK_THREAD_POOL_CONFIG, "0")
+    map.put(CassandraConfigConstants.THREAD_POOL_CONFIG, "0")
     val settings = CassandraSettings.configureSink(CassandraConfigSink(map))
     settings.threadPoolSize shouldBe 4 * Runtime.getRuntime.availableProcessors()
   }

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/config/TestCassandraSourceSettings.scala
@@ -45,7 +45,7 @@ class TestCassandraSourceSettings extends WordSpec with Matchers with TestConfig
       CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
       CassandraConfigConstants.USERNAME -> USERNAME,
       CassandraConfigConstants.PASSWD -> PASSWD,
-      CassandraConfigConstants.SOURCE_KCQL_QUERY -> "INSERT INTO cassandra-source SELECT * FROM orders PK created",
+      CassandraConfigConstants.ROUTE_QUERY -> "INSERT INTO cassandra-source SELECT * FROM orders PK created",
       CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
       CassandraConfigConstants.POLL_INTERVAL -> "1000"
     )

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraSinkConnector.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/sink/TestCassandraSinkConnector.scala
@@ -28,7 +28,7 @@ class TestCassandraSinkConnector extends WordSpec with BeforeAndAfter with Match
     val connector = new CassandraSinkConnector()
     connector.start(props)
     val taskConfigs = connector.taskConfigs(1)
-    taskConfigs.asScala.head.get(CassandraConfigConstants.SINK_KCQL) shouldBe QUERY_ALL
+    taskConfigs.asScala.head.get(CassandraConfigConstants.ROUTE_QUERY) shouldBe QUERY_ALL
     taskConfigs.asScala.head.get(CassandraConfigConstants.CONTACT_POINTS) shouldBe CONTACT_POINT
     taskConfigs.asScala.head.get(CassandraConfigConstants.KEY_SPACE) shouldBe TOPIC1
     taskConfigs.size() shouldBe 1

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceConnector.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceConnector.scala
@@ -31,7 +31,7 @@ class TestCassandraSourceConnector extends WordSpec with Matchers with TestConfi
     val connector = new CassandraSourceConnector()
     connector.start(props)
     val taskConfigs = connector.taskConfigs(1)
-    taskConfigs.asScala.head.get(CassandraConfigConstants.SOURCE_KCQL_QUERY) shouldBe IMPORT_QUERY_ALL
+    taskConfigs.asScala.head.get(CassandraConfigConstants.ROUTE_QUERY) shouldBe IMPORT_QUERY_ALL
     taskConfigs.asScala.head.get(CassandraConfigConstants.CONTACT_POINTS) shouldBe CONTACT_POINT
     taskConfigs.asScala.head.get(CassandraConfigConstants.KEY_SPACE) shouldBe TOPIC1
     taskConfigs.asScala.head.get(CassandraConfigConstants.ASSIGNED_TABLES) shouldBe ASSIGNED_TABLES

--- a/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
+++ b/kafka-connect-cassandra/src/test/scala/com/datamountaineer/streamreactor/connect/cassandra/source/TestCassandraSourceTaskSpecifyColumns.scala
@@ -68,7 +68,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE3 PK timestamp_field",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE3 PK timestamp_field",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE3",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000",
@@ -123,7 +123,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 PK timestamp_field",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 PK timestamp_field",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
@@ -177,7 +177,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
@@ -231,7 +231,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field FROM $TABLE2 PK timestamp_field",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field FROM $TABLE2 PK timestamp_field",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
@@ -267,7 +267,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field WITHUNWRAP",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field WITHUNWRAP",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava
@@ -321,7 +321,7 @@ class TestCassandraSourceTaskSpecifyColumns extends WordSpec with Matchers with 
         CassandraConfigConstants.KEY_SPACE -> CASSANDRA_KEYSPACE,
         CassandraConfigConstants.USERNAME -> USERNAME,
         CassandraConfigConstants.PASSWD -> PASSWD,
-        CassandraConfigConstants.SOURCE_KCQL_QUERY -> s"INSERT INTO sink_test SELECT string_field, long_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field WITHUNWRAP",
+        CassandraConfigConstants.ROUTE_QUERY -> s"INSERT INTO sink_test SELECT string_field, long_field, timestamp_field FROM $TABLE2 IGNORE timestamp_field PK timestamp_field WITHUNWRAP",
         CassandraConfigConstants.ASSIGNED_TABLES -> s"$TABLE2",
         CassandraConfigConstants.IMPORT_MODE -> CassandraConfigConstants.INCREMENTAL,
         CassandraConfigConstants.POLL_INTERVAL -> "1000").asJava


### PR DESCRIPTION
Refactor of the Cassandra connector constant’s keywords, so that they do not mention sink/source