### PR TITLE
Refactor of constants tests, so values match the correct connector names

### DIFF
--- a/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkConstants.scala
+++ b/kafka-connect-hazelcast/src/test/scala/com/datamountaineer/streamreactor/connect/hazelcast/config/TestHazelCastSinkConstants.scala
@@ -16,12 +16,12 @@
 
 package com.datamountaineer.streamreactor.connect.hazelcast.config
 
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.WordSpec
 
 /**
   * The point of this test is to check that constants keys are not changed after the refactor of the code.
   */
-class TestHazelCastSinkConstants extends WordSpec with BeforeAndAfter with Matchers {
+class TestHazelCastSinkConstants extends WordSpec {
 
   // Constants
   val CLUSTER_MEMBERS = "connect.hazelcast.cluster.members"
@@ -41,13 +41,13 @@ class TestHazelCastSinkConstants extends WordSpec with BeforeAndAfter with Match
   val NBR_OF_RETRIES = "connect.hazelcast.max.retries"
   val THREAD_POOL_CONFIG = "connect.hazelcast.threadpool.size"
 
-  "CLUSTER_SOURCE_MEMBERS should have the same key in HazelCastSinkConfigConstants" in {
+  "CLUSTER_MEMBERS should have the same key in HazelCastSinkConfigConstants" in {
     assert(CLUSTER_MEMBERS.equals(HazelCastSinkConfigConstants.CLUSTER_MEMBERS))
   }
-  "SINK_GROUP_NAME should have the same key in HazelCastSinkConfigConstants" in {
+  "GROUP_NAME should have the same key in HazelCastSinkConfigConstants" in {
     assert(GROUP_NAME.equals(HazelCastSinkConfigConstants.GROUP_NAME))
   }
-  "SINK_GROUP_PASSWORD should have the same key in HazelCastSinkConfigConstants" in {
+  "GROUP_PASSWORD should have the same key in HazelCastSinkConfigConstants" in {
     assert(GROUP_PASSWORD.equals(HazelCastSinkConfigConstants.GROUP_PASSWORD))
   }
   "PARALLEL_WRITE should have the same key in HazelCastSinkConfigConstants" in {
@@ -86,7 +86,7 @@ class TestHazelCastSinkConstants extends WordSpec with BeforeAndAfter with Match
   "NBR_OF_RETRIES should have the same key in HazelCastSinkConfigConstants" in {
     assert(NBR_OF_RETRIES.equals(HazelCastSinkConfigConstants.NBR_OF_RETRIES))
   }
-  "SINK_THREAD_POOL_CONFIG should have the same key in HazelCastSinkConfigConstants" in {
+  "THREAD_POOL_CONFIG should have the same key in HazelCastSinkConfigConstants" in {
     assert(THREAD_POOL_CONFIG.equals(HazelCastSinkConfigConstants.THREAD_POOL_CONFIG))
   }
 }

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSinkConstants.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSinkConstants.scala
@@ -16,18 +16,18 @@
 
 package com.datamountaineer.streamreactor.connect.rethink.config
 
-import com.datamountaineer.streamreactor.connect.rethink.TestBase
+import org.scalatest.WordSpec
 
 /**
   * The point of this test is to check that constants keys are not changed after the refactor of the code.
   */
-class TestReThinkSinkConstants extends TestBase {
+class TestReThinkSinkConstants extends WordSpec {
 
   // Constants
   val RETHINK_HOST = "connect.rethink.host"
   val RETHINK_DB = "connect.rethink.db"
   val RETHINK_PORT = "connect.rethink.port"
-  val EXPORT_ROUTE_QUERY = "connect.rethink.kcql"
+  val ROUTE_QUERY = "connect.rethink.kcql"
   val ERROR_POLICY = "connect.rethink.error.policy"
   val ERROR_RETRY_INTERVAL = "connect.rethink.retry.interval"
   val NBR_OF_RETRIES = "connect.rethink.max.retries"
@@ -45,8 +45,8 @@ class TestReThinkSinkConstants extends TestBase {
     assert(RETHINK_PORT.equals(ReThinkSinkConfigConstants.RETHINK_PORT))
   }
 
-  "EXPORT_ROUTE_QUERY should have the same key in ReThinkSinkConfigConstants" in {
-    assert(EXPORT_ROUTE_QUERY.equals(ReThinkSinkConfigConstants.ROUTE_QUERY))
+  "ROUTE_QUERY should have the same key in ReThinkSinkConfigConstants" in {
+    assert(ROUTE_QUERY.equals(ReThinkSinkConfigConstants.ROUTE_QUERY))
   }
 
   "ERROR_POLICY should have the same key in ReThinkSinkConfigConstants" in {

--- a/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSourceConstants.scala
+++ b/kafka-connect-rethink/src/test/scala/com/datamountaineer/streamreactor/connect/rethink/config/TestReThinkSourceConstants.scala
@@ -16,18 +16,18 @@
 
 package com.datamountaineer.streamreactor.connect.rethink.config
 
-import com.datamountaineer.streamreactor.connect.rethink.TestBase
+import org.scalatest.WordSpec
 
 /**
   * The point of this test is to check that constants keys are not changed after the refactor of the code.
   */
-class TestReThinkSourceConstants extends TestBase {
+class TestReThinkSourceConstants extends WordSpec {
 
   // Constants
   val RETHINK_HOST ="connect.rethink.host"
   val RETHINK_DB ="connect.rethink.db"
   val RETHINK_PORT ="connect.rethink.port"
-  val IMPORT_ROUTE_QUERY ="connect.rethink.kcql"
+  val ROUTE_QUERY ="connect.rethink.kcql"
 
   "RETHINK_HOST should have the same key in ReThinkSinkConfigConstants" in {
     assert(RETHINK_HOST.equals(ReThinkSourceConfigConstants.RETHINK_HOST))
@@ -41,7 +41,7 @@ class TestReThinkSourceConstants extends TestBase {
     assert(RETHINK_PORT.equals(ReThinkSourceConfigConstants.RETHINK_PORT))
   }
 
-  "EXPORT_ROUTE_QUERY should have the same key in ReThinkSinkConfigConstants" in {
-    assert(IMPORT_ROUTE_QUERY.equals(ReThinkSourceConfigConstants.ROUTE_QUERY))
+  "ROUTE_QUERY should have the same key in ReThinkSinkConfigConstants" in {
+    assert(ROUTE_QUERY.equals(ReThinkSourceConfigConstants.ROUTE_QUERY))
   }
 }


### PR DESCRIPTION
Refactor of constants tests, so values match the correct connector names.
Organize imports